### PR TITLE
Update for the list of illegal websites

### DIFF
--- a/SITES.md
+++ b/SITES.md
@@ -110,6 +110,7 @@ Rated sites. The score goes from 1 to 5. 1 is good, 5 is bad.
 | minecraftgig ru                    |      1      |        5       |   3   |       |
 | minecraftgood com                  |      5      |        5       |   5   |       |
 | minecrafthd com                    |      3      |        5       |   1   |       |
+| minecrafthut com                   |      4      |        4       |   3   | Also distributes hacked clients |
 | minecraftiamodpack blogspot com    |      5      |        5       |   5   |       |
 | minecraftiamods com                |      5      |        5       |   1   |       |
 | minecraftjardl com                 |      3      |        5       |   5   | **Malware alert!** |


### PR DESCRIPTION
minecrafthut.com is at best the mod-stealing site that distributes mods and maps without prior permission of the author and at worst distributes hacked clients and mods. (check the index 113)